### PR TITLE
add support find coffeescript file extension for store

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -897,12 +897,13 @@ Catberry uses following parameters from it:
 * componentsGlob – glob expression for searching cat-components,
 can be an string array or just a string
 (`['catberry_components/**/cat-component.json','node_modules/*/cat-component.json']` by default)
+* storesGlob - glob expression for searching stores (`'**/*.js'` by default)
 * storesDirectory – relative path to the directory with stores
-("./catberry_stores" by default)
+(`'./catberry_stores'` by default)
 * publicDirectoryPath – path to public directory
-("./public" by default)
+(`'./public'` by default)
 * bundleFilename – name of the browser bundle file
-("bundle.js" by default)
+(`bundle.js` by default)
 
 ## UHR (Universal HTTP(S) Request)
 Catberry has Universal HTTP(S) Request service registered as "uhr" in

--- a/lib/finders/StoreFinder.js
+++ b/lib/finders/StoreFinder.js
@@ -40,7 +40,7 @@ var path = require('path'),
 	glob = require('glob');
 
 var DEFAULT_STORES_ROOT = 'catberry_stores',
-	STORES_GLOB = '**/*.@(js|coffee)';
+	DEFAULT_STORES_GLOB = '**/*.js';
 
 var CHOKIDAR_OPTIONS = {
 	ignoreInitial: true,
@@ -54,14 +54,15 @@ util.inherits(StoreFinder, events.EventEmitter);
  * Creates new instance of store finder.
  * @param {EventEmitter} $eventBus Event bus to exchange events.
  * @param {String} storesDirectory Relative path to directory with store files.
+ * @param {String} storesGlob Glob expression for searching stores
  * @extends EventEmitter
  * @constructor
  */
-function StoreFinder($eventBus, storesDirectory) {
+function StoreFinder($eventBus, storesDirectory, storesGlob) {
 	events.EventEmitter.call(this);
 	this._eventBus = $eventBus;
 	this._storesDirectory = storesDirectory || DEFAULT_STORES_ROOT;
-	this._storesGlobExpression = path.join(this._storesDirectory, STORES_GLOB);
+	this._storesGlobExpression = path.join(this._storesDirectory, storesGlob || DEFAULT_STORES_GLOB);
 	this._storesGlobExpression = requireHelper.getValidPath(
 		this._storesGlobExpression
 	);

--- a/lib/finders/StoreFinder.js
+++ b/lib/finders/StoreFinder.js
@@ -40,7 +40,7 @@ var path = require('path'),
 	glob = require('glob');
 
 var DEFAULT_STORES_ROOT = 'catberry_stores',
-	STORES_GLOB = '**/*.js';
+	STORES_GLOB = '**/*.@(js|coffee)';
 
 var CHOKIDAR_OPTIONS = {
 	ignoreInitial: true,
@@ -148,7 +148,7 @@ StoreFinder.prototype.find = function () {
  */
 StoreFinder.prototype._createStoreDescriptor = function (filename) {
 	var relative = path.relative(this._storesDirectory, filename),
-		basename = path.basename(relative, '.js'),
+		basename = path.basename(relative, path.extname(filename)),
 		directory = path.dirname(relative),
 		storeName = directory !== '.' ?
 		path.dirname(relative) + path.sep + basename : basename;


### PR DESCRIPTION
Hello.
I'm added support compilation CoffeScript files (https://github.com/mass3ff3ct/catberry-coffee)
But, StoreFinder search only .js files in catberry_stores.
I added the ability to search for files with the extension .coffee