### PR TITLE
Fix #284: fatal error when watch and remove modules

### DIFF
--- a/lib/finders/ComponentFinder.js
+++ b/lib/finders/ComponentFinder.js
@@ -320,8 +320,8 @@ class ComponentFinder extends events.EventEmitter {
 
 		requireHelper.clearCacheKey(absolutePath);
 
-		this._foundComponentsByNames.delete(component.name);
-		this._foundComponentsByDirs.delete(dirName);
+		delete this._foundComponentsByNames[component.name];
+		delete this._foundComponentsByDirs[dirName];
 
 		if (this._fileWatcher) {
 			this._fileWatcher.unwatch(dirName);

--- a/lib/finders/StoreFinder.js
+++ b/lib/finders/StoreFinder.js
@@ -121,7 +121,7 @@ class StoreFinder extends events.EventEmitter {
 			})
 			.on('unlink', filename => {
 				const store = this._createStoreDescriptor(filename);
-				this._foundStoresByNames.delete(store.name);
+				delete this._foundStoresByNames[store.name];
 				this.emit('unlink', store);
 			});
 	}


### PR DESCRIPTION
There was an experiment with replacing bare objects we use with new fancy `Map` type in JavaScript. The changes were cancelled eventually but the `delete` method calls were left for some reason. As far as we don't have unit tests for watching components/stores for changes we could not detect that. 

So, we need to create tests for such cases somehow.