### PR TITLE
Fix #298: Update outdated packages.

### DIFF
--- a/browser/DocumentRenderer.js
+++ b/browser/DocumentRenderer.js
@@ -252,7 +252,7 @@ class DocumentRenderer extends DocumentRendererBase {
 						}
 
 						morphdom(element, tmpElement, {
-							onBeforeMorphElChildren: foundElement =>
+							onBeforeElUpdated: foundElement =>
 								foundElement === element || !this._isComponentElement(
 									renderingContext.components, foundElement
 								)

--- a/package.json
+++ b/package.json
@@ -92,15 +92,15 @@
 		"uglify-js": "^2.6.2",
 		"browserify": "^13.0.0",
 		"promise": "^7.1.1",
-		"morphdom": "^1.1.2",
+		"morphdom": "^2.0.4",
 		"uuid": "^2.0.1"
 	},
 	"devDependencies": {
 		"istanbul": "~0.4.2",
 		"codecov": "^1.0.1",
-		"jsdom": "^8.0.4",
-		"mocha": "^2.4.5",
-		"eslint": "^2.2.0"
+		"jsdom": "^9.4.2",
+		"mocha": "^3.0.2",
+		"eslint": "^3.3.1"
 	},
 	"engines": {
 		"node": ">=4"

--- a/test/lib/finders/ComponentFinder.js
+++ b/test/lib/finders/ComponentFinder.js
@@ -35,7 +35,7 @@ describe('lib/finders/ComponentFinder', function() {
 				componentsGlob: 'test/**/test-cat-component.json'
 			});
 			const finder = locator.resolve('componentFinder');
-			return finder
+			finder
 				.find()
 				.then(found => assert.deepEqual(found, EXPECTED))
 				.then(done)
@@ -52,7 +52,7 @@ describe('lib/finders/ComponentFinder', function() {
 				]
 			});
 			const finder = locator.resolve('componentFinder');
-			return finder
+			finder
 				.find()
 				.then(found => assert.deepEqual(found, EXPECTED))
 				.then(done)


### PR DESCRIPTION
This commit updates jsdom, eslint, mocha and morpdom to the last
versions.
There was one broken changed with Morphdom that required to rename
`onBeforeMorphEl` to `onBeforeElUpdated`.