### PR TITLE
Remove "Build Date" from bundle.js

### DIFF
--- a/lib/builders/BrowserBundleBuilder.js
+++ b/lib/builders/BrowserBundleBuilder.js
@@ -27,7 +27,6 @@ try {
 		packageDescriptionString = `
 /**
  * ${packageDescription.name}: ${packageDescription.version}
- * Build Date: ${(new Date()).toString()}
  */
 
 `;


### PR DESCRIPTION
We have a problem with different `bundle.js` on different app-node after released new version.