### PR TITLE
Change morphdom version limiting to 2.2.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
 		"uglify-js": "^2.6.2",
 		"browserify": "^13.0.0",
 		"promise": "^7.1.1",
-		"morphdom": "^2.0.4",
+		"morphdom": "~2.2.0",
 		"uuid": "^2.0.1"
 	},
 	"devDependencies": {


### PR DESCRIPTION
Suddenly the rendering tests started failing because of some introduced breaking change from morphdom package.