### PR TITLE
Add app and externals code splitting

### DIFF
--- a/browser/Bootstrapper.js
+++ b/browser/Bootstrapper.js
@@ -1,30 +1,10 @@
-/**
- * This file is a template and it is used only for some string replaces
- * by BrowserBundleBuilder module. It does not work by itself.
- */
-
 'use strict';
 
-const stores = [
-
-/** __stores **/
-
-];
-
-const components = [
-
-/** __components **/
-
-];
-
-const routeDefinitions = '__routeDefinitions' || [];
-const routeDescriptors = '__routes' || [];
-
-const Catberry = require('./node_modules/catberry/browser/Catberry.js');
-const BootstrapperBase = require('./node_modules/catberry/lib/base/BootstrapperBase.js');
-const StoreDispatcher = require('./node_modules/catberry/lib/StoreDispatcher');
-const ModuleApiProvider = require('./node_modules/catberry/browser/providers/ModuleApiProvider');
-const CookieWrapper = require('./node_modules/catberry/browser/CookieWrapper');
+const Catberry = require('./Catberry.js');
+const BootstrapperBase = require('../lib/base/BootstrapperBase');
+const StoreDispatcher = require('../lib/StoreDispatcher');
+const ModuleApiProvider = require('./providers/ModuleApiProvider');
+const CookieWrapper = require('./CookieWrapper');
 
 class Bootstrapper extends BootstrapperBase {
 
@@ -48,16 +28,6 @@ class Bootstrapper extends BootstrapperBase {
 		locator.register('cookieWrapper', CookieWrapper, true);
 
 		locator.registerInstance('window', window);
-
-		routeDefinitions.forEach(routeDefinition =>
-			locator.registerInstance('routeDefinition', routeDefinition));
-
-		routeDescriptors.forEach(routeDescriptor =>
-			locator.registerInstance('routeDescriptor', routeDescriptor));
-
-		stores.forEach(store => locator.registerInstance('store', store));
-
-		components.forEach(component => locator.registerInstance('component', component));
 	}
 }
 

--- a/browser/Catberry.js
+++ b/browser/Catberry.js
@@ -28,6 +28,19 @@ class Catberry extends CatberryBase {
 	 * Wraps current HTML document with Catberry event handlers.
 	 */
 	wrapDocument() {
+		const appDefinitions = require('appDefinitions');
+		appDefinitions.routeDefinitions
+			.forEach(routeDefinition => this.locator.registerInstance('routeDefinition', routeDefinition));
+
+		appDefinitions.routeDescriptors
+			.forEach(routeDescriptor => this.locator.registerInstance('routeDescriptor', routeDescriptor));
+
+		appDefinitions.stores
+			.forEach(store => this.locator.registerInstance('store', store));
+
+		appDefinitions.components
+			.forEach(component => this.locator.registerInstance('component', component));
+
 		this._router = this.locator.resolve('requestRouter');
 	}
 

--- a/lib/Bootstrapper.js
+++ b/lib/Bootstrapper.js
@@ -5,7 +5,7 @@ const StoreDispatcher = require('./StoreDispatcher');
 const ModuleApiProvider = require('./providers/ModuleApiProvider');
 const CookieWrapper = require('./CookieWrapper');
 const BrowserBundleBuilder = require('./builders/BrowserBundleBuilder');
-const BootstrapperBuilder = require('./builders/BootstrapperBuilder');
+const AppDefinitionsBuilder = require('./builders/AppDefinitionsBuilder');
 const StoreFinder = require('./finders/StoreFinder');
 const ComponentFinder = require('./finders/ComponentFinder');
 const BootstrapperBase = require('./base/BootstrapperBase');
@@ -42,7 +42,7 @@ class Bootstrapper extends BootstrapperBase {
 		locator.register('cookieWrapper', CookieWrapper);
 
 		locator.register('browserBundleBuilder', BrowserBundleBuilder, true);
-		locator.register('bootstrapperBuilder', BootstrapperBuilder, true);
+		locator.register('appDefinitionsBuilder', AppDefinitionsBuilder, true);
 		locator.register('storeFinder', StoreFinder, true);
 		locator.register('componentFinder', ComponentFinder, true);
 

--- a/lib/appDefinitions.js
+++ b/lib/appDefinitions.js
@@ -1,0 +1,28 @@
+/**
+ * This file is a template and it is used only for some string replaces
+ * by BrowserBundleBuilder module. It does not work by itself.
+ */
+
+'use strict';
+
+const stores = [
+
+/** __stores **/
+
+];
+
+const components = [
+
+/** __components **/
+
+];
+
+const routeDefinitions = '__routeDefinitions' || [];
+const routeDescriptors = '__routes' || [];
+
+module.exports = {
+	stores,
+	components,
+	routeDefinitions,
+	routeDescriptors
+};

--- a/lib/builders/AppDefinitionsBuilder.js
+++ b/lib/builders/AppDefinitionsBuilder.js
@@ -7,8 +7,8 @@ const moduleHelper = require('../helpers/moduleHelper');
 const requireHelper = require('../helpers/requireHelper');
 const RouteParser = require('../tokenizers/RouteParser');
 
-const BOOTSTRAPPER_FILENAME = 'Bootstrapper.js';
-const BROWSER_ROOT_PATH = path.join(__dirname, '..', '..', 'browser');
+const APP_DEFINITIONS_FILENAME = 'appDefinitions.js';
+const LIB_ROOT_PATH = path.join(__dirname, '..');
 const STORES_REPLACE = '/** __stores **/';
 const COMPONENTS_REPLACE = '/** __components **/';
 const ROUTE_DESCRIPTORS_REPLACE = '\'__routes\'';
@@ -16,12 +16,12 @@ const ROUTE_DEFINITIONS_REPLACE = '\'__routeDefinitions\'';
 const ROUTE_DEFINITIONS_FILENAME = 'routes.js';
 
 /**
- * Implements the bootstrapper builder module.
+ * Implements the app definitions builder module.
  */
-class BootstrapperBuilder {
+class AppDefinitionsBuilder {
 
 	/**
-	 * Creates a new instance of the bootstrapper builder.
+	 * Creates a new instance of the app definitions builder.
 	 * @param {ServiceLocator} locator The Service Locator for resolving dependencies.
 	 */
 	constructor(locator) {
@@ -49,15 +49,15 @@ class BootstrapperBuilder {
 	}
 
 	/**
-	 * Creates a real bootstrapper code from the template.
+	 * Creates a real app definitions code from the template.
 	 * @param {Object} stores The found stores by their names.
 	 * @param {Object} components The found components by their names.
-	 * @returns {Promise<string>} The promise for the source code of the bootstrapper.
+	 * @returns {Promise<string>} The promise for the source code of the app definitions.
 	 */
 	build(stores, components) {
-		const bootstrapperTemplatePath = path.join(
-			BROWSER_ROOT_PATH,
-			BOOTSTRAPPER_FILENAME
+		const appDefinitionsTemplatePath = path.join(
+			LIB_ROOT_PATH,
+			APP_DEFINITIONS_FILENAME
 		);
 		const routeDefinitionsPath = path.join(
 			process.cwd(),
@@ -65,9 +65,9 @@ class BootstrapperBuilder {
 		);
 
 		const startTime = hrTimeHelper.get();
-		this._eventBus.emit('info', `Building bootstrapper using the template "${bootstrapperTemplatePath}"...`);
+		this._eventBus.emit('info', `Building app definitions using the template "${appDefinitionsTemplatePath}"...`);
 
-		return pfs.readFile(bootstrapperTemplatePath, {
+		return pfs.readFile(appDefinitionsTemplatePath, {
 			encoding: 'utf8'
 		})
 			.then(file => Promise
@@ -112,14 +112,14 @@ class BootstrapperBuilder {
 							.replace(ROUTE_DESCRIPTORS_REPLACE, JSON.stringify(routeDescriptors));
 					})
 			)
-			.then(boostrapper => {
+			.then(appDefinitions => {
 				const hrTime = hrTimeHelper.get(startTime);
-				this._eventBus.emit('bootsrapperBuilt', {
-					template: bootstrapperTemplatePath,
+				this._eventBus.emit('appDefinitionsBuilt', {
+					template: appDefinitionsTemplatePath,
 					hrTime,
 					time: hrTimeHelper.toMilliseconds(hrTime)
 				});
-				return boostrapper;
+				return appDefinitions;
 			})
 			.catch(reason => this._eventBus.emit('error', reason));
 	}
@@ -275,7 +275,7 @@ class BootstrapperBuilder {
 }
 
 /**
- * Escapes template source code for including into the bootstrapper.
+ * Escapes template source code for including into the app definitions.
  * @param {string} source The compiled template source.
  * @returns {string} The escaped string.
  */
@@ -288,4 +288,4 @@ function escapeTemplateSource(source) {
 		.replace(/\t/g, '\\t');
 }
 
-module.exports = BootstrapperBuilder;
+module.exports = AppDefinitionsBuilder;

--- a/lib/builders/BrowserBundleBuilder.js
+++ b/lib/builders/BrowserBundleBuilder.js
@@ -12,15 +12,18 @@ const browserify = require('browserify');
 const hrTimeHelper = require('../helpers/hrTimeHelper');
 const UglifyTransform = require('../streams/UglifyTransform');
 
-const DEFAULT_PUBLIC_DIRECTORY = path.join(process.cwd(), 'public');
-const TEMPORARY_BOOTSTRAPPER_FILENAME = '__BrowserBundle.js';
+const WORKING_DIR = process.cwd();
+const DEFAULT_PUBLIC_DIRECTORY = path.join(WORKING_DIR, 'public');
+const TEMPORARY_APP_DEFINITIONS_FILENAME = '.appDefinitions.js';
 const BROWSER_SCRIPT_FILENAME = 'browser.js';
-const BUNDLE_FILENAME = 'bundle.js';
+const APP_DEFAULT_FILENAME = 'app.js';
+const EXTERNALS_DEFAULT_FILENAME = 'externals.js';
+const APP_DEPENDENCY_ID_REGEXP = process.platform === 'win32' ?	/^(\.|\w:)/ :	/^[\/.]/;
 
 var packageDescriptionString = '';
 
 try {
-	const packageDescription = require(path.join(process.cwd(), 'package.json'));
+	const packageDescription = require(path.join(WORKING_DIR, 'package.json'));
 	if (packageDescription &&
 		packageDescription.name &&
 		packageDescription.version) {
@@ -63,25 +66,32 @@ class BrowserBundleBuilder {
 		this._publicPath = config.publicDirectoryPath || DEFAULT_PUBLIC_DIRECTORY;
 
 		/**
-		 * Current path to the bundle.js.
+		 * Current path to the application bundle file.
 		 * @type {string}
 		 * @private
 		 */
-		this._bundlePath = path.join(this._publicPath, (config.bundleFilename || BUNDLE_FILENAME));
+		this._appPath = path.join(this._publicPath, (config.appBundleFilename || APP_DEFAULT_FILENAME));
 
 		/**
-		 * Current path to the __BrowserBundle.js.
+		 * Current path to the externals bunlde file.
 		 * @type {string}
 		 * @private
 		 */
-		this._bootstrapperPath = path.join(process.cwd(), TEMPORARY_BOOTSTRAPPER_FILENAME);
+		this._externalsPath = path.join(this._publicPath, (config.externalsBundleFilename || EXTERNALS_DEFAULT_FILENAME));
+
+		/**
+		 * Current path to the __appDefinitions.js.
+		 * @type {string}
+		 * @private
+		 */
+		this._appDefinitionsPath = path.join(WORKING_DIR, TEMPORARY_APP_DEFINITIONS_FILENAME);
 
 		/**
 		 * Current path to the browser.js.
 		 * @type {string}
 		 * @private
 		 */
-		this._entryPath = path.join(process.cwd(), BROWSER_SCRIPT_FILENAME);
+		this._entryPath = path.join(WORKING_DIR, BROWSER_SCRIPT_FILENAME);
 
 		/**
 		 * Current service locator.
@@ -98,11 +108,11 @@ class BrowserBundleBuilder {
 		this._eventBus = locator.resolve('eventBus');
 
 		/**
-		 * Current bootstrapper builder.
-		 * @type {BootstrapperBuilder}
+		 * Current app definitions builder.
+		 * @type {AppDefinitionsBuilder}
 		 * @private
 		 */
-		this._bootstrapperBuilder = locator.resolve('bootstrapperBuilder');
+		this._appDefinitionsBuilder = locator.resolve('appDefinitionsBuilder');
 
 		/**
 		 * Current component finder.
@@ -155,18 +165,32 @@ class BrowserBundleBuilder {
 		}
 
 		/**
-		 * Current Browserify bundler.
+		 * Current Browserify app bundler.
 		 * @type {Browserify}
 		 * @private
 		 */
-		this._bundler = null;
+		this._appBundler = null;
 
 		/**
-		 * Current bootstrapper cache.
+		 * Current Browserify externals bundler.
+		 * @type {Browserify}
+		 * @private
+		 */
+		this._externalsBundler = null;
+
+		/**
+		 * Current set of external modules.
+		 * @type {Object}
+		 * @private
+		 */
+		this._externalModules = {};
+
+		/**
+		 * Current app definitions cache.
 		 * @type {string}
 		 * @private
 		 */
-		this._bootstrapperCache = '';
+		this._appDefinitionsCache = '';
 	}
 
 	/**
@@ -176,8 +200,8 @@ class BrowserBundleBuilder {
 	build() {
 		return pfs.exists(this._publicPath)
 			.then(isExists => !isExists ? makeDirectory(this._publicPath) : null)
-			.then(() => this._createBootstrapper())
-			.then(() => new Promise((fulfill, reject) => this._createBundler()
+			.then(() => this._createAppDefinitions())
+			.then(() => new Promise((fulfill, reject) => this._createAppBundler()
 					.once('error', reject)
 					.once('bundle', bundleStream => bundleStream
 							.once('end', fulfill)
@@ -186,62 +210,171 @@ class BrowserBundleBuilder {
 					.bundle()
 				)
 			)
+			.then(() => new Promise((fulfill, reject) => this._createExternalsBundler()
+					.once('error', reject)
+					.once('bundle', bundleStream => bundleStream
+							.once('end', fulfill)
+							.on('error', reject)
+					)
+					.bundle()
+				)
+			)
+
 			.then(() => this._doPostBuildActions())
 			.then(() => this._isRelease ?
-					pfs.unlink(this._bootstrapperPath) :
+					pfs.unlink(this._appDefinitionsPath) :
 					this._watch()
 			)
 			.catch(reason => this._eventBus.emit('error', reason));
 	}
 
 	/**
-	 * Creates a bootstrapper file for the bundler.
+	 * Creates a app definitions file for the bundler.
 	 * @returns {Promise} The promise for finished work.
 	 * @private
 	 */
-	_createBootstrapper() {
+	_createAppDefinitions() {
 		return Promise.all([
 			this._storeFinder.find(),
 			this._componentFinder.find()
 		])
-			.then(found => this._bootstrapperBuilder.build(found[0], found[1]))
-			.then(realBootstrapper => {
-				if (realBootstrapper === this._bootstrapperCache) {
+			.then(found => this._appDefinitionsBuilder.build(found[0], found[1]))
+			.then(realAppDefinitions => {
+				if (realAppDefinitions === this._appDefinitionsCache) {
 					return null;
 				}
-				this._bootstrapperCache = realBootstrapper;
-				return pfs.writeFile(this._bootstrapperPath, realBootstrapper);
+				this._appDefinitionsCache = realAppDefinitions;
+				return pfs.writeFile(this._appDefinitionsPath, realAppDefinitions);
 			});
 	}
 
 	/**
-	 * Creates the browserify bundler or re-uses the existing one.
+	 * Creates the browserify bundler for the app or re-uses the existing one.
 	 * @returns {Browserify} The browserify instance.
 	 * @private
 	 */
-	_createBundler() {
-		if (this._bundler) {
-			return this._bundler;
+	_createAppBundler() {
+		if (this._appBundler) {
+			return this._appBundler;
 		}
 
-		this._bundler = browserify([this._entryPath], {
+		this._appBundler = browserify(this._entryPath, {
+			cache: {},
+			packageCache: {},
+			debug: !this._isRelease,
+			filter: id => {
+				if (APP_DEPENDENCY_ID_REGEXP.test(id)) {
+					return true;
+				}
+				this._externalModules[id] = true;
+				return false;
+			}
+		});
+
+		this._appBundler.require(
+			this._appDefinitionsPath, {expose: 'appDefinitions'}
+		);
+		this._appBundler.external('catberry');
+
+		if (!this._isRelease) {
+			this._appBundler.plugin(watchify);
+			this._eventBus.emit('info', 'Watching files for changes to rebuild the app bundle...');
+		}
+
+		this._attachExtensionsToBundler(this._appBundler);
+
+		var startTime;
+		const resetHandler = () => {
+			this._eventBus.emit('info', `Building browser script bundle for the app at "${this._appPath}"...`);
+			startTime = hrTimeHelper.get();
+		};
+
+		this._appBundler
+			.on('update', ids => {
+				this._eventBus.emit('appBundleChanged', {
+					path: this._appPath,
+					changedFiles: ids
+				});
+
+				this._appBundler.bundle();
+			})
+			.on('error', error => this._eventBus.emit('error', error))
+			.on('reset', resetHandler)
+			.on('bundle', sourceStream => {
+				const outputStream = fs.createWriteStream(this._appPath);
+				if (this._isRelease) {
+					outputStream.write(packageDescriptionString);
+				}
+				outputStream.once('finish', () => {
+					const hrTime = hrTimeHelper.get(startTime);
+					this._eventBus.emit('appBundleBuilt', {
+						path: this._appPath,
+						hrTime,
+						time: hrTimeHelper.toMilliseconds(hrTime)
+					});
+				});
+				sourceStream.pipe(outputStream);
+			});
+
+		resetHandler(); // to set startTime universally.
+		return this._appBundler;
+	}
+
+	/**
+	 * Creates the browserify bundler for externals or re-uses the existing one.
+	 * @returns {Browserify} The browserify instances.
+	 * @private
+	 */
+	_createExternalsBundler() {
+		if (this._externalsBundler) {
+			return this._externalsBundler;
+		}
+
+		this._externalsBundler = browserify({
 			cache: {},
 			packageCache: {},
 			debug: !this._isRelease
-		})
-			.transform(babelify, {
-				global: true,
-				ast: false,
-				comments: false,
-				sourceMap: !this._isRelease,
-				presets: [babelifyPreset]
+		});
+		this._externalsBundler.require(Object.keys(this._externalModules));
+		this._externalsBundler.external('appDefinitions');
+		this._attachExtensionsToBundler(this._externalsBundler);
+
+		const startTime = hrTimeHelper.get();
+		this._eventBus.emit('info', `Building browser script bundle for externals at "${this._externalsPath}"...`);
+
+		this._externalsBundler
+			.on('error', error => this._eventBus.emit('error', error))
+			.on('bundle', sourceStream => {
+				const outputStream = fs.createWriteStream(this._externalsPath);
+				outputStream.once('finish', () => {
+					const hrTime = hrTimeHelper.get(startTime);
+					this._eventBus.emit('externalsBundleBuilt', {
+						path: this._externalsPath,
+						hrTime,
+						time: hrTimeHelper.toMilliseconds(hrTime)
+					});
+				});
+				sourceStream.pipe(outputStream);
 			});
 
-		if (!this._isRelease) {
-			this._bundler.plugin(watchify);
-			this._eventBus.emit('info', 'Watching files for changes to rebuild the bundle...');
-		} else {
-			this._bundler.transform(file => {
+		return this._externalsBundler;
+	}
+
+	/**
+	 * Attaches necessary plugins and transformations to the bundle.
+	 * @param {Browserify} bundler The bundler to attach extensions.
+	 */
+	_attachExtensionsToBundler(bundler) {
+		bundler.transform(babelify, {
+			global: true,
+			ast: false,
+			comments: false,
+			sourceMap: !this._isRelease,
+			presets: [babelifyPreset]
+		});
+
+		if (this._isRelease) {
+			bundler.transform(file => {
 				if (path.extname(file) !== '.js') {
 					return new stream.PassThrough();
 				}
@@ -252,44 +385,8 @@ class BrowserBundleBuilder {
 			});
 		}
 
-		this._setTransformations();
-		this._setPlugins();
-
-		var startTime;
-		const resetHandler = () => {
-			this._eventBus.emit('info', `Building browser script bundle at "${this._bundlePath}"...`);
-			startTime = hrTimeHelper.get();
-		};
-
-		this._bundler
-			.on('update', ids => {
-				this._eventBus.emit('bundleChanged', {
-					path: this._bundlePath,
-					changedFiles: ids
-				});
-
-				this._bundler.bundle();
-			})
-			.on('error', error => this._eventBus.emit('error', error))
-			.on('reset', resetHandler)
-			.on('bundle', sourceStream => {
-				const outputStream = fs.createWriteStream(this._bundlePath);
-				if (this._isRelease) {
-					outputStream.write(packageDescriptionString);
-				}
-				outputStream.once('finish', () => {
-					const hrTime = hrTimeHelper.get(startTime);
-					this._eventBus.emit('bundleBuilt', {
-						path: this._bundlePath,
-						hrTime,
-						time: hrTimeHelper.toMilliseconds(hrTime)
-					});
-				});
-				sourceStream.pipe(outputStream);
-			});
-
-		resetHandler(); // to set startTime universally.
-		return this._bundler;
+		this._setTransformations(bundler);
+		this._setPlugins(bundler);
 	}
 
 	/**
@@ -328,7 +425,7 @@ class BrowserBundleBuilder {
 	 * @private
 	 */
 	_watch() {
-		const watchHandler = this._createBootstrapper.bind(this);
+		const watchHandler = this._createAppDefinitions.bind(this);
 		this._componentFinder.watch();
 		this._componentFinder
 			.on('add', watchHandler)
@@ -357,7 +454,7 @@ class BrowserBundleBuilder {
 				this._eventBus.emit('warn', 'The browserify transformation has an incorrect interface, skipping...');
 				continue;
 			}
-			this._bundler.transform(
+			this._appBundler.transform(
 				currentTransformation.transform, currentTransformation.options
 			);
 		}
@@ -378,7 +475,7 @@ class BrowserBundleBuilder {
 				this._eventBus.emit('warn', 'The browserify plugin has an incorrect interface, skipping...');
 				continue;
 			}
-			this._bundler.plugin(
+			this._appBundler.plugin(
 				currentPlugin.plugin, currentPlugin.options
 			);
 		}

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 
 	"main": "./index",
 	"browser": {
-		"./lib/Bootstrapper.js": "__BrowserBundle.js",
+		"./lib/Bootstrapper.js": "./browser/Bootstrapper.js",
 		"./lib/Catberry.js": "./browser/Catberry.js",
 		"./lib/CookieWrapper.js": "./browser/CookieWrapper.js",
 		"./lib/providers/ModuleApiProvider.js": "./browser/providers/ModuleApiProvider.js",


### PR DESCRIPTION
Details in #209.

## What's new
Now Catberry splits the bunlde.js into 2 files:
* apps.js - components, stores, routes
* externals.js - any dependency from `node_modules` directory. You can aggressively cache this file until you change the dependency list in you project.

The point is that you can deploy the small `app.js` only and your users will still have a cached `externals.js` which is the most part of the code of any project.

Another reason for this change is debug mode optimization, no Catberry only watches and rebuilds files only related to your app code not including any file from `node_modules`. It should dramatically improve the debug mode performance.

## Breaking changes
* Now any project using catberry has to include 2 `script` tags for both scripts: externals.js and app.js (in this particular order).
* Config parameters changed:
  * `bundleFilename` => `appBundleFilename` (default `app.js`)
  * added `externalsBundleFilename` (default `externals.js`)
* Event names changes:
  * `bundleBuilt` => `appBundleBuild`
  * `bundleChanged` => `appBundleChanged`
  * `bootstrapperBuild` => `appDefinitionsBuilt`
  * added `externalsBundleBuild` event