### PR TITLE
Resolve #319: Drop IE10 support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ class CoolComponent {
 	 */
 	bind() {
 		return {
-		    // CSS selector
-		    '.clickable': () => window.alert('Ouch!');
+			// CSS selector
+			'.clickable': () => window.alert('Ouch!');
 		}
 	}
 
@@ -187,8 +187,8 @@ All supported browsers are listed below:
 
 | Browser			| Version		|
 |-------------|-----------|
-| IE | 9 (partial non-[SPA](http://en.wikipedia.org/wiki/Single-page_application)), 10+ |
-| IE Mobile | 10+ |
+| IE | 9-10 (w/o client part, only server rendering), 11+ |
+| IE Mobile | 11+ |
 | Firefox | 4+ |
 | Firefox Android | 29+ |
 | Chrome | 19+ |

--- a/lib/builders/BrowserBundleBuilder.js
+++ b/lib/builders/BrowserBundleBuilder.js
@@ -7,7 +7,7 @@ const pfs = require('../promises/fs');
 const mkdirp = require('mkdirp');
 const watchify = require('watchify');
 const babelify = require('babelify');
-const babelifyPreset = require('babel-preset-es2015-ie');
+const babelEnv = require('babel-preset-env');
 const browserify = require('browserify');
 const hrTimeHelper = require('../helpers/hrTimeHelper');
 const UglifyTransform = require('../streams/UglifyTransform');
@@ -365,12 +365,21 @@ class BrowserBundleBuilder {
 	 * @param {Browserify} bundler The bundler to attach extensions.
 	 */
 	_attachExtensionsToBundler(bundler) {
+		const isDebug = !this._isRelease;
+
 		bundler.transform(babelify, {
 			global: true,
 			ast: false,
 			comments: false,
-			sourceMap: !this._isRelease,
-			presets: [babelifyPreset]
+			presets: [[
+				babelEnv, {
+					targets: {
+						uglify: true // we have to transform to ES5 to make UglifyJS work
+					},
+					debug: isDebug
+				}
+			]],
+			sourceMap: isDebug
 		});
 
 		if (this._isRelease) {
@@ -379,6 +388,7 @@ class BrowserBundleBuilder {
 					return new stream.PassThrough();
 				}
 				this._eventBus.emit('trace', `Minifying code of the file "${file}"...`);
+				// TODO: migrate to Babili when it's ready
 				return new UglifyTransform();
 			}, {
 				global: true

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
 		"entities": "^1.1.1",
 		"watchify": "^3.7.0",
 		"babelify": "^7.2.0",
-		"babel-preset-es2015-ie": "^6.6.1",
+		"babel-preset-env": "^1.2.2",
 		"uglify-js": "^2.6.2",
 		"browserify": "^13.0.0",
 		"promise": "^7.1.1",


### PR DESCRIPTION
Now Catberry uses the `babel-preset-env` package and the target 'uglify'. When
Babili (Babel minifier) is ready we can allow users to specify their own
targets as a part of their .babelrc file, but it's not supported yet
because UglifyJS doe not support >=ES2015.