### PR TITLE
Resolve #325: Drop Node.js < 6.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,5 @@ notifications:
 language: node_js
 sudo: false
 node_js:
-  - "4"
-  - "5"
   - "6"
+  - "7"

--- a/lib/promises/promiseHelper.js
+++ b/lib/promises/promiseHelper.js
@@ -9,11 +9,8 @@ module.exports = {
 	 */
 	callbackToPromise: methodWithCallback => {
 
-		/* eslint prefer-rest-params:0 */
 		/* eslint no-invalid-this:0 */
-		// TODO rewrite this when Spread operator and Rest parameters will be supported
-		return function() {
-			const args = Array.prototype.slice.call(arguments);
+		return function(...args) {
 			return new Promise((fulfill, reject) => {
 				args.push((error, result) => {
 					if (error) {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
 		"rimraf": "^2.5.4"
 	},
 	"engines": {
-		"node": ">=4"
+		"node": ">=6.10"
 	},
 	"scripts": {
 		"test": "make"


### PR DESCRIPTION
We support 2 last versions. 6.10 is the current LTS release and 7.x is
the last version.