### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,30 +83,30 @@
 	},
 	"dependencies": {
 		"mkdirp": "~0.5.1",
-		"glob": "^7.0.0",
-		"chokidar": "^1.4.3",
-		"catberry-locator": "^2.1.0",
-		"catberry-uri": "^3.1.0",
-		"pretty-hrtime": "^1.0.2",
+		"glob": "^7.1.1",
+		"chokidar": "^1.6.1",
+		"catberry-locator": "^2.2.1",
+		"catberry-uri": "^3.2.2",
+		"pretty-hrtime": "^1.0.3",
 		"browser-process-hrtime": "~0.1.2",
 		"entities": "^1.1.1",
-		"watchify": "^3.7.0",
-		"babelify": "^7.2.0",
+		"watchify": "^3.9.0",
+		"babelify": "^7.3.0",
 		"babel-preset-env": "^1.2.2",
-		"uglify-js": "^2.6.2",
-		"browserify": "^13.0.0",
+		"uglify-js": "^2.8.13",
+		"browserify": "^14.1.0",
 		"promise": "^7.1.1",
 		"morphdom": "~2.2.0",
-		"uuid": "^2.0.1"
+		"uuid": "^3.0.1"
 	},
 	"devDependencies": {
-		"istanbul": "~0.4.2",
-		"codecov": "^1.0.1",
-		"jsdom": "^9.4.2",
-		"mocha": "^3.0.2",
-		"eslint": "^3.3.1",
+		"istanbul": "~0.4.5",
+		"codecov": "^2.1.0",
+		"jsdom": "^9.12.0",
+		"mocha": "^3.2.0",
+		"eslint": "^3.18.0",
 		"ncp": "^2.0.0",
-		"rimraf": "^2.5.4"
+		"rimraf": "^2.6.1"
 	},
 	"engines": {
 		"node": ">=6.10"


### PR DESCRIPTION
Finally we can update browserify to [14.x](https://github.com/substack/node-browserify/blob/master/changelog.markdown#1400) because we dropped support for IE <= 10.