### PR TITLE
Add checks for null when render a document.

### DIFF
--- a/lib/streams/ComponentReadable.js
+++ b/lib/streams/ComponentReadable.js
@@ -19,7 +19,7 @@ const HTML_ENTITY_REFERENCE_REGEXP = /\&#?\w+;/ig;
 class ComponentReadable extends stream.Readable {
 
 	/**
-	 * Creates q new instance of the parser duplex stream.
+	 * Creates a new instance of the parser duplex stream.
 	 * @param {Object} context Rendering parameters.
 	 * @param {Object?} options Stream options.
 	 */
@@ -96,8 +96,12 @@ class ComponentReadable extends stream.Readable {
 		this._processingFoundTagPromise = this._foundComponentHandler({
 			name: moduleHelper.DOCUMENT_COMPONENT_NAME,
 			attributes: Object.create(null)
-		})
-			.then(html => this.renderHTML(html));
+		});
+
+		if (this._processingFoundTagPromise) {
+			this._processingFoundTagPromise = this._processingFoundTagPromise
+				.then(html => this.renderHTML(html));
+		}
 	}
 
 	/**

--- a/test/lib/streams/ComponentReadable.js
+++ b/test/lib/streams/ComponentReadable.js
@@ -39,10 +39,30 @@ describe('lib/streams/ComponentReadable', function() {
 			});
 		});
 	});
+
+	describe('#renderDocument', function() {
+		it('renders nothing when there is no document', function(done) {
+			const parser = new ComponentReadable(createContext());
+
+			parser.renderDocument();
+
+			var concat = '';
+			parser
+				.on('data', function(chunk) {
+					concat += chunk;
+				})
+				.on('end', function() {
+					assert.strictEqual(concat, '', 'Wrong HTML content');
+					done();
+				});
+		});
+	});
+
 });
 
 function createContext() {
 	return {
+		components: Object.create(null),
 		routingContext: {
 			middleware: {
 				response: new ServerResponse(),


### PR DESCRIPTION
Fix #333. Previously if the document component was not defined Catberry
failed with an error but the expected behavior should be just an empty response.