### PR TITLE
Add context.error(statusCode) function

### DIFF
--- a/browser/providers/ModuleApiProvider.js
+++ b/browser/providers/ModuleApiProvider.js
@@ -40,6 +40,16 @@ class ModuleApiProvider extends ModuleApiProviderBase {
 	}
 
 	/**
+	 * Reloads the page for handling error page.
+	 * @returns {Promise} Promise for nothing.
+	 */
+	error() {
+		const window = this.locator.resolve('window');
+		window.location.reload();
+		return Promise.resolve();
+	}
+
+	/**
 	 * Redirects current page to specified URI.
 	 * @param {string} uriString URI to redirect.
 	 * @returns {Promise} Promise for nothing.

--- a/lib/providers/ModuleApiProvider.js
+++ b/lib/providers/ModuleApiProvider.js
@@ -24,7 +24,7 @@ class ModuleApiProvider extends ModuleApiProviderBase {
 		 */
 		this.actions = {
 			redirectedTo: '',
-			isNotFoundCalled: false,
+			errorStatusCode: 200,
 			isFragmentCleared: false
 		};
 	}
@@ -51,7 +51,17 @@ class ModuleApiProvider extends ModuleApiProviderBase {
 	 * @returns {Promise} The promise for finished work.
 	 */
 	notFound() {
-		this.actions.isNotFoundCalled = true;
+		this.actions.errorStatusCode = 404;
+		return Promise.resolve();
+	}
+
+	/**
+	 * Sets error HTTP status code
+	 * @param {number} statusCode - HTTP status code.
+	 * @returns {Promise} The promise for finished work.
+	 */
+	error(statusCode) {
+		this.actions.errorStatusCode = statusCode || 200;
 		return Promise.resolve();
 	}
 

--- a/lib/streams/ComponentReadable.js
+++ b/lib/streams/ComponentReadable.js
@@ -427,17 +427,19 @@ class ComponentReadable extends stream.Readable {
 			return;
 		}
 
-		if (routingContext.actions.isNotFoundCalled) {
-			routingContext.actions.isNotFoundCalled = false;
-			this._isCanceled = true;
-			routingContext.middleware.next();
-			return;
-		}
-
 		const headers = {
 			'Content-Type': CONTENT_TYPE,
 			'X-Powered-By': POWERED_BY
 		};
+
+		if (routingContext.actions.errorStatusCode >= 400) {
+			response.writeHead(routingContext.actions.errorStatusCode, headers);
+			routingContext.actions.errorStatusCode = null;
+			this._isCanceled = true;
+			this.push(null);
+			return;
+		}
+
 		if (routingContext.cookie.setCookie.length > 0) {
 			headers['Set-Cookie'] = routingContext.cookie.setCookie;
 		}

--- a/test/lib/providers/ModuleApiProvider.js
+++ b/test/lib/providers/ModuleApiProvider.js
@@ -134,6 +134,15 @@ describe('lib/providers/ModuleApiProvider', function() {
 		});
 	});
 
+	describe('#error', function(done) {
+		it('should return 500 HTTP status code', function() {
+			api.error(500)
+				.then(() => assert.strictEqual(api.actions.errorStatusCode, 500))
+				.then(done)
+				.catch(done);
+		});
+	});
+
 	describe('#getRouteURI', function() {
 		it('should call state provider', function() {
 			assert.strictEqual(api.getRouteURI('name', {some: 'value'}), 'testURI:name:{"some":"value"}');


### PR DESCRIPTION
Add context.error(statusCode) function for proxy errors code from API.
For example, if API returned 500 HTTP status code than return 500 page.